### PR TITLE
Fix error handling middleware

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -22,7 +22,10 @@ app.use(cors());
 
 app.use('/api', require('./api'));
 
-app.use((err, req, res) => {
+// Disable ESLint for this line because of the issue listed here :
+// https://github.com/expressjs/generator/issues/78
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
   // Log error message in our server's console
   console.error(err.message);
   // If err has no specified error code, set error code to 'Internal Server Error (500)'


### PR DESCRIPTION
The error handling middleware was failing to do its job so I fixed it.
However it implied to disable ESlint on 1 line as you can see in the changes.
@nymous have you ever encountered this issue ?