### PR TITLE
Fix/exam backend

### DIFF
--- a/backend/src/api/ressources/exams/controller.js
+++ b/backend/src/api/ressources/exams/controller.js
@@ -44,13 +44,12 @@ const controller = {
   },
 
   async editExercice(req, res, next) {
+    const { exercice } = res.locals;
     if (req.body) {
       try {
-        const result = await ExerciceData.update(req.params.exerciceId, req.body);
-        if (!result) {
-          return res.status(404).send('Exercice not Found');
-        }
-        return res.status(200).json(result);
+        exercice.update(req.body);
+        exercice.save();
+        return res.status(200).json(req.body);
       } catch (error) {
         return next(error);
       }
@@ -58,13 +57,12 @@ const controller = {
   },
 
   async editExam(req, res, next) {
+    const { exam } = res.locals;
     if (req.body) {
       try {
-        const result = await ExamData.update(req.params.examId, req.body);
-        if (!result) {
-          return res.status(404).send('Exam not Found');
-        }
-        return res.status(200).json(result);
+        exam.update(req.body);
+        await exam.save();
+        return res.status(200).json(req.body);
       } catch (error) {
         return next(error);
       }
@@ -102,13 +100,12 @@ const controller = {
    * @param {Object} next
    */
   async editQuestionById(req, res, next) {
+    const { question } = res.locals;
     if (req.body) {
       try {
-        const result = await QuestionData.update(req.params.questionId, req.body);
-        if (!result) {
-          return res.status(404).send('Not Found');
-        }
-        return res.status(200).json(result);
+        await question.updateOne(req.body);
+        await question.save();
+        return res.status(200).json(req.body);
       } catch (error) {
         return next(error);
       }

--- a/backend/src/api/ressources/exams/controller.js
+++ b/backend/src/api/ressources/exams/controller.js
@@ -125,14 +125,14 @@ const controller = {
     }
   },
 
-  deleteExerciceById(req, res, next) {
+  async deleteExerciceById(req, res, next) {
     const { exercice, exam } = res.locals;
     if (exercice) {
       try {
         const deletePromise = exercice.delete();
         exam.exercices = exam.exercices.filter(id => id !== exercice.id);
         const savePromise = exam.save();
-        Promise.all([deletePromise, savePromise]);
+        await Promise.all([deletePromise, savePromise]);
         return res.status(204).send();
       } catch (error) {
         next(error);
@@ -140,14 +140,14 @@ const controller = {
     } return res.status(400).send('Bad Request...');
   },
 
-  deleteQuestionById(req, res, next) {
+  async deleteQuestionById(req, res, next) {
     const { exercice, question } = res.locals;
     if (question) {
       try {
         const deletePromise = question.delete();
         exercice.questions = exercice.questions.filter(id => id !== question.id);
         const savePromise = exercice.save();
-        Promise.all([deletePromise, savePromise]);
+        await Promise.all([deletePromise, savePromise]);
         return res.status(204).send();
       } catch (error) {
         next(error);

--- a/backend/src/api/ressources/exams/index.js
+++ b/backend/src/api/ressources/exams/index.js
@@ -223,7 +223,7 @@ router.post('/', ExamController.newExam);
  *
  * @apiSuccess (201) {json} Exam a JSON object containing the edited document
  */
-router.patch('/:examId', ExamController.editExam);
+router.patch('/:examId', ExamMiddlewares.findExamOrReturn, ExamController.editExam);
 
 /**
  * @api {delete} /exam/:examId Delete an exam
@@ -267,7 +267,7 @@ router.post('/:examId/exercices', ExamMiddlewares.findExamOrReturn, ExamControll
  *
  * @apiSuccess (201) {json} Exercice a JSON object containing the edited document
  */
-router.patch('/:examId/exercices/:exerciceId', ExamController.editExercice);
+router.patch('/:examId/exercices/:exerciceId', ExamMiddlewares.findExamOrReturn, ExamMiddlewares.findExerciceOrReturn, ExamController.editExercice);
 
 /**
  * @api {delete} /exam/:examId/exercices/:exerciceId Delete an exercice
@@ -312,7 +312,7 @@ router.post('/:examId/exercices/:exerciceId/questions', ExamController.newQuesti
  *
  * @apiSuccess (201) {json} Question a JSON object containing the edited document
  */
-router.patch('/:examId/exercices/:exerciceId/questions/:questionId', ExamController.editQuestionById);
+router.patch('/:examId/exercices/:exerciceId/questions/:questionId', ExamMiddlewares.findExamOrReturn, ExamMiddlewares.findExerciceOrReturn, ExamMiddlewares.findQuestionOrReturn, ExamController.editQuestionById);
 
 
 /**

--- a/backend/src/api/ressources/exams/index.js
+++ b/backend/src/api/ressources/exams/index.js
@@ -237,7 +237,7 @@ router.patch('/:examId', ExamController.editExam);
 router.delete('/:examId', ExamMiddlewares.findExamOrReturn, ExamController.deleteExamById);
 
 /**
- * @api {post} /exam/:examId/exercice Create a new exercice
+ * @api {post} /exam/:examId/exercices Create a new exercice
  * @apiName CreateExercice
  * @apiGroup Exercices
  * @apiDescription This URL creates a new exercice in the exam requested in the url
@@ -251,10 +251,10 @@ router.delete('/:examId', ExamMiddlewares.findExamOrReturn, ExamController.delet
  *
  * @apiSuccess (201) {json} Exercice a JSON object containing the created document
  */
-router.post('/:examId/exercice', ExamMiddlewares.findExamOrReturn, ExamController.newExerciceOfExam);
+router.post('/:examId/exercices', ExamMiddlewares.findExamOrReturn, ExamController.newExerciceOfExam);
 
 /**
- * @api {patch} /exam/:examId/exercice/:exerciceId Edit an exercice
+ * @api {patch} /exam/:examId/exercices/:exerciceId Edit an exercice
  * @apiName EditExercice
  * @apiGroup Exercices
  * @apiDescription This URL edit an exercice from its id
@@ -267,10 +267,10 @@ router.post('/:examId/exercice', ExamMiddlewares.findExamOrReturn, ExamControlle
  *
  * @apiSuccess (201) {json} Exercice a JSON object containing the edited document
  */
-router.patch('/:examId/exercice/:exerciceId', ExamController.editExercice);
+router.patch('/:examId/exercices/:exerciceId', ExamController.editExercice);
 
 /**
- * @api {delete} /exam/:examId/exercice/:exerciceId Delete an exercice
+ * @api {delete} /exam/:examId/exercices/:exerciceId Delete an exercice
  * @apiName DeleteExercice
  * @apiGroup Exercices
  * @apiDescription This URL deletes an exercice of an exam based on both ids.
@@ -278,10 +278,10 @@ router.patch('/:examId/exercice/:exerciceId', ExamController.editExercice);
  * @apiSuccess (204) {null} null Empty date to return
  *
  */
-router.delete('/:examId/exercice/:exerciceId', ExamMiddlewares.findExamOrReturn, ExamMiddlewares.findExerciceOrReturn, ExamController.deleteExerciceById);
+router.delete('/:examId/exercices/:exerciceId', ExamMiddlewares.findExamOrReturn, ExamMiddlewares.findExerciceOrReturn, ExamController.deleteExerciceById);
 
 /**
- * @api {post} /exam/:examId/exercice/:exerciceId/question Create a new question
+ * @api {post} /exam/:examId/exercices/:exerciceId/questions Create a new question
  * @apiName CreateQuestion
  * @apiGroup Questions
  * @apiDescription This URL creates a new question in the exercice requested
@@ -296,10 +296,10 @@ router.delete('/:examId/exercice/:exerciceId', ExamMiddlewares.findExamOrReturn,
  *
  * @apiSuccess (201) {json} Question a JSON object containing the created document
  */
-router.post('/:examId/exercice/:exerciceId/question', ExamController.newQuestionOfExercice);
+router.post('/:examId/exercices/:exerciceId/questions', ExamController.newQuestionOfExercice);
 
 /**
- * @api {patch} /exam/:examId/exercice/:exerciceId/question/:questionId Edit a question
+ * @api {patch} /exam/:examId/exercices/:exerciceId/questions/:questionId Edit a question
  * @apiName EditQuestion
  * @apiGroup Questions
  * @apiDescription This URL edit a question from its id
@@ -312,11 +312,11 @@ router.post('/:examId/exercice/:exerciceId/question', ExamController.newQuestion
  *
  * @apiSuccess (201) {json} Question a JSON object containing the edited document
  */
-router.patch('/:examId/exercice/:exerciceId/question/:questionId', ExamController.editQuestionById);
+router.patch('/:examId/exercices/:exerciceId/questions/:questionId', ExamController.editQuestionById);
 
 
 /**
- * @api {delete} /exam/:examId/exercice/:exerciceId/question/:questionId Delete a question
+ * @api {delete} /exam/:examId/exercices/:exerciceId/questions/:questionId Delete a question
  * @apiName DeleteQuestion
  * @apiGroup Questions
  * @apiDescription This URL deletes a question from its id
@@ -324,6 +324,6 @@ router.patch('/:examId/exercice/:exerciceId/question/:questionId', ExamControlle
  *
  * @apiSuccess (204) {null} null Empty date to return
  */
-router.delete('/:examId/exercice/:exerciceId/question/:questionId', ExamMiddlewares.findExamOrReturn, ExamMiddlewares.findExerciceOrReturn, ExamMiddlewares.findQuestionOrReturn, ExamController.deleteQuestionById);
+router.delete('/:examId/exercices/:exerciceId/questions/:questionId', ExamMiddlewares.findExamOrReturn, ExamMiddlewares.findExerciceOrReturn, ExamMiddlewares.findQuestionOrReturn, ExamController.deleteQuestionById);
 
 module.exports = router;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,10 +10,6 @@ const config = require('./config');
 // setup database connexion
 require('./config/mongoose');
 
-app.use(bodyParser.urlencoded({
-  extended: false,
-}));
-
 app.use(bodyParser.json());
 
 // Enable CORS

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ const cors = require('cors');
 const express = require('express');
 const serveStatic = require('serve-static');
 const bodyParser = require('body-parser');
+const path = require('path');
 
 const app = express();
 const server = require('http').Server(app);
@@ -34,4 +35,8 @@ app.use(serveStatic('./public'));
 server.listen(config.app.port, (err) => {
   if (err) console.error(err);
   else console.log(`Listening on port ${config.app.port}`);
+});
+
+app.get('/*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });


### PR DESCRIPTION
This branch just applies some fixes on the backend.
I wanted to use the mongoose $pull technique, but it doesn't remove the subdocument from the database so this operation would leave use with plenty of "exercices" without any parent exam and so on.
(https://docs.mongodb.com/manual/reference/operator/update/pull/ && https://mongoosejs.com/docs/api.html#mongoosearray_MongooseArray-pull )

Note that now with your restclient, you have to use JSON to test the backend : 
![image](https://user-images.githubusercontent.com/18481465/52912268-695ed900-32af-11e9-9402-19d72356555a.png)
![image](https://user-images.githubusercontent.com/18481465/52912270-724faa80-32af-11e9-9012-45913da08667.png)
