### PR TITLE
Feature/add exercices questions order

### DIFF
--- a/backend/src/api/ressources/exams/controller.js
+++ b/backend/src/api/ressources/exams/controller.js
@@ -101,12 +101,13 @@ const controller = {
    * @param {Object} next
    */
   async editQuestionById(req, res, next) {
-    const { question } = res.locals;
+    const { exercice, question } = res.locals;
     if (req.body) {
       try {
-        await question.updateOne(req.body);
-        await question.save();
-        return res.status(200).json(req.body);
+        await QuestionData.updateOrderOfOtherQuestionsIfNeeded(exercice, question, req.body.order);
+        await QuestionData.update(question._id, req.body);
+        const result = await QuestionData.getById(question._id);
+        return res.status(200).json(result);
       } catch (error) {
         return next(error);
       }

--- a/backend/src/api/ressources/exams/controller.js
+++ b/backend/src/api/ressources/exams/controller.js
@@ -44,12 +44,13 @@ const controller = {
   },
 
   async editExercice(req, res, next) {
-    const { exercice } = res.locals;
+    const { exam, exercice } = res.locals;
     if (req.body) {
       try {
-        exercice.update(req.body);
-        exercice.save();
-        return res.status(200).json(req.body);
+        await ExerciceData.updateOrderOfOtherExercicesIfNeeded(exam, exercice, req.body.order);
+        await ExerciceData.update(exercice._id, req.body);
+        const result = await ExerciceData.getById(req.body._id);
+        return res.status(200).json(result);
       } catch (error) {
         return next(error);
       }

--- a/backend/src/api/ressources/exams/controller.js
+++ b/backend/src/api/ressources/exams/controller.js
@@ -47,7 +47,7 @@ const controller = {
     const { exam, exercice } = res.locals;
     if (req.body) {
       try {
-        await ExerciceData.updateOrderOfOtherExercicesIfNeeded(exam, exercice, req.body.order);
+        await ExerciceData.updateOrderOfOtherExercices(exam, exercice, req.body.order);
         await ExerciceData.update(exercice._id, req.body);
         const result = await ExerciceData.getById(req.body._id);
         return res.status(200).json(result);
@@ -104,7 +104,7 @@ const controller = {
     const { exercice, question } = res.locals;
     if (req.body) {
       try {
-        await QuestionData.updateOrderOfOtherQuestionsIfNeeded(exercice, question, req.body.order);
+        await QuestionData.updateOrderOfOtherQuestions(exercice, question, req.body.order);
         await QuestionData.update(question._id, req.body);
         const result = await QuestionData.getById(question._id);
         return res.status(200).json(result);

--- a/backend/src/services/exam/data.js
+++ b/backend/src/services/exam/data.js
@@ -12,7 +12,12 @@ module.exports = {
       options: {
         sort: { order: +1 },
       },
-      populate: { path: 'questions' },
+      populate: {
+        path: 'questions',
+        options: {
+          sort: { order: +1 },
+        },
+      },
     }),
   create: (exam) => {
     const examToSave = new Exam(exam);

--- a/backend/src/services/exam/data.js
+++ b/backend/src/services/exam/data.js
@@ -9,6 +9,9 @@ module.exports = {
   getById: async id => Exam.findById(id)
     .populate({
       path: 'exercices',
+      options: {
+        sort: { order: +1 },
+      },
       populate: { path: 'questions' },
     }),
   create: (exam) => {

--- a/backend/src/services/exercice/data.js
+++ b/backend/src/services/exercice/data.js
@@ -22,7 +22,7 @@ module.exports = {
    * @param {Exercice} exercice the exercice that's being dragged and dropped
    * @param {number} newExerciceOrder the new order of the exercice that's being dragged and dropped
    */
-  async updateOrderOfOtherExercicesIfNeeded(exam, exercice, newExerciceOrder) {
+  async updateOrderOfOtherExercices(exam, exercice, newExerciceOrder) {
     const promisesUpdateOrder = exam.exercices.map(async (syblingExercice) => {
       // if it is a different exercice than the one we are updating
       // and if it has a higher order

--- a/backend/src/services/exercice/data.js
+++ b/backend/src/services/exercice/data.js
@@ -3,7 +3,8 @@ const Exercice = require('./model');
 module.exports = {
   create: async (request, exam) => {
     const exerciceToSave = new Exercice(request);
-    exerciceToSave.order = exerciceToSave.order || exam.exercices.length;
+    const maxOrder = Math.max(...exam.exercices.map(ex => ex.order));
+    exerciceToSave.order = exerciceToSave.order || maxOrder + 1;
     const exercice = await exerciceToSave.save();
     exam.exercices.push(exercice._id);
     await exam.save();

--- a/backend/src/services/exercice/data.js
+++ b/backend/src/services/exercice/data.js
@@ -10,7 +10,7 @@ module.exports = {
     await exam.save();
     return exercice;
   },
-  getById: async id => Exercice.findById(id),
+  getById: async id => Exercice.findById(id).populate('questions'),
   update: async (_id, exercice) => Exercice.findOneAndUpdate({ _id }, exercice),
   delete: async _id => Exercice.findByIdAndDelete(_id),
 

--- a/backend/src/services/exercice/data.js
+++ b/backend/src/services/exercice/data.js
@@ -3,6 +3,7 @@ const Exercice = require('./model');
 module.exports = {
   create: async (request, exam) => {
     const exerciceToSave = new Exercice(request);
+    exerciceToSave.order = exerciceToSave.order || exam.exercices.length;
     const exercice = await exerciceToSave.save();
     exam.exercices.push(exercice._id);
     await exam.save();
@@ -11,4 +12,28 @@ module.exports = {
   getById: async id => Exercice.findById(id),
   update: async (_id, exercice) => Exercice.findOneAndUpdate({ _id }, exercice),
   delete: async _id => Exercice.findByIdAndDelete(_id),
+
+
+  /**
+   * Updates the order of the other exercices that are contained
+   * in the same exam if it is needed
+   * @param {Exam} exam the parent exam that contains the exercices
+   * @param {Exercice} exercice the exercice that's being dragged and dropped
+   * @param {number} newExerciceOrder the new order of the exercice that's being dragged and dropped
+   */
+  async updateOrderOfOtherExercicesIfNeeded(exam, exercice, newExerciceOrder) {
+    const promisesUpdateOrder = exam.exercices.map(async (syblingExercice) => {
+      // if it is a different exercice than the one we are updating
+      // and if it has a higher order
+      // then increment its order
+      if (syblingExercice._id !== exercice._id && syblingExercice.order >= newExerciceOrder) {
+        const newSyblingExercice = syblingExercice;
+        newSyblingExercice.order += 1;
+        await newSyblingExercice.save();
+      }
+      return true;
+    });
+    // wait for all the exercises to be updated
+    await Promise.all(promisesUpdateOrder);
+  },
 };

--- a/backend/src/services/exercice/model.js
+++ b/backend/src/services/exercice/model.js
@@ -10,6 +10,11 @@ const ExerciceSchema = new mongoose.Schema({
     required: false,
     trim: true,
   },
+  order: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
   questions: [{
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Question',

--- a/backend/src/services/question/data.js
+++ b/backend/src/services/question/data.js
@@ -12,4 +12,29 @@ module.exports = {
   },
   getById: async id => Question.findById(id),
   update: async (_id, question) => Question.findOneAndUpdate({ _id }, question),
+
+  /**
+   * Updates the order of the other questions that are contained
+   * in the same exercice if it is needed
+   * @param {Exercice} exercice the parent exercice that contains the questions
+   * @param {Question} question the question that's being dragged and dropped
+   * @param {number} newQuestionOrder the new order of the question that's being dragged and dropped
+   */
+  async updateOrderOfOtherQuestionsIfNeeded(exercice, question, newQuestionOrder) {
+    const promisesUpdateOrder = exercice.questions.map(async (syblingQuestion) => {
+      // if it is a different question than the one we are updating
+      // and if it has a higher order
+      // then increment its order
+      if (syblingQuestion._id !== question._id && syblingQuestion.order >= newQuestionOrder) {
+        console.log('Sybling question to update', syblingQuestion.order);
+        const newSyblingQuestion = syblingQuestion;
+        newSyblingQuestion.order += 1;
+        console.log('New Question order', newSyblingQuestion.order);
+        await newSyblingQuestion.save();
+      }
+      return true;
+    });
+    // wait for all the questions to be updated
+    await Promise.all(promisesUpdateOrder);
+  },
 };

--- a/backend/src/services/question/data.js
+++ b/backend/src/services/question/data.js
@@ -3,6 +3,8 @@ const Question = require('./model');
 module.exports = {
   create: async (request, exercice) => {
     const questionToSave = new Question(request);
+    const maxOrder = Math.max(...exercice.questions.map(q => q.order));
+    questionToSave.order = questionToSave.order || maxOrder + 1;
     const question = await questionToSave.save();
     exercice.questions.push(question._id);
     await exercice.save();

--- a/backend/src/services/question/data.js
+++ b/backend/src/services/question/data.js
@@ -20,7 +20,7 @@ module.exports = {
    * @param {Question} question the question that's being dragged and dropped
    * @param {number} newQuestionOrder the new order of the question that's being dragged and dropped
    */
-  async updateOrderOfOtherQuestionsIfNeeded(exercice, question, newQuestionOrder) {
+  async updateOrderOfOtherQuestions(exercice, question, newQuestionOrder) {
     const promisesUpdateOrder = exercice.questions.map(async (syblingQuestion) => {
       // if it is a different question than the one we are updating
       // and if it has a higher order

--- a/backend/src/services/question/model.js
+++ b/backend/src/services/question/model.js
@@ -10,6 +10,11 @@ const QuestionSchema = new mongoose.Schema({
     required: true,
     trim: true,
   },
+  order: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
   correction: {
     type: String,
     trim: true,


### PR DESCRIPTION
This branch implements the backend for allowing to update the order of an exercice or a question.
It takes inspiration from what M. Bourdeaud'huy did for our exam on Backend & Frontend development. 
(this kind of feature is a nightmare to test with postman haha)


I updated the routes for updating an exercice or a question.
I chose to requery the database to send the *effectively updated* document. This is not great in terms of performance, but I haven't found any other solution for the moment.
If we want to gain in performance, we can do just like before and send the `req.body` back to the user