### PR TITLE
Fix path to production frontend

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -38,5 +38,5 @@ server.listen(config.app.port, (err) => {
 });
 
 app.get('/*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+  res.sendFile(path.join(__dirname, '../public', 'index.html'));
 });


### PR DESCRIPTION
Production was failing because of a wrong path.
To test how production works, I had to do this : 
`cd frontend && npm run build && cd .. && cp -R frontend/build backend/app/public && cd backend && npm start`
With `mongod` running in another terminal